### PR TITLE
Policies: No need to use HTML character for validator

### DIFF
--- a/Source/Common/Policies.cpp
+++ b/Source/Common/Policies.cpp
@@ -506,10 +506,10 @@ void Policies::create_values_from_csv()
         { "", "" },
         { "=", "Equal" },
         { "!=", "Not Equal" },
-        { "&gt", "Greater than" },
-        { "&ge", "Greater or equal" },
-        { "&lt", "Less" },
-        { "&le", "Less or equal" }
+        { ">", "Greater than" },
+        { ">=", "Greater or equal" },
+        { "<", "Less" },
+        { "<=", "Less or equal" }
     };
 
     for (size_t i=0; i < (sizeof(validators) / sizeof(*validators)); i++)


### PR DESCRIPTION
Libxml2 already encodes the character ('>' and '<') to HTML code.

Signed-off-by: Florent Tribouilloy <florent@mediaarea.net>