### PR TITLE
declares script type as CSS

### DIFF
--- a/Source/Resource/displays/MediaConchHtml.xsl
+++ b/Source/Resource/displays/MediaConchHtml.xsl
@@ -5,7 +5,7 @@
   <html>
   <head>
     <title>MediaConch</title>
-    <style>
+    <style type="text/css">
       .mc_header {
         width: 100%;
         max-width: 1280px;


### PR DESCRIPTION
This reduces one validation error, by declaring what kind of script in the embedded CSS.