### PR TITLE
GUI: Use UTF-8 and not local when saving report

### DIFF
--- a/Source/GUI/Qt/WebEnginePage.cpp
+++ b/Source/GUI/Qt/WebEnginePage.cpp
@@ -88,6 +88,7 @@ namespace MediaConch
             return;
 
         QTextStream out(&file);
+        out.setCodec("UTF-8");
         out << report;
     }
 

--- a/Source/GUI/Qt/WebKitPage.cpp
+++ b/Source/GUI/Qt/WebKitPage.cpp
@@ -94,6 +94,7 @@ namespace MediaConch
             return;
 
         QTextStream out(&file);
+        out.setCodec("UTF-8");
         out << report;
     }
 


### PR DESCRIPTION
Signed-off-by: Florent Tribouilloy <florent@mediaarea.net>