### PR TITLE
Avoid 2 internal memory copies of the trace

### DIFF
--- a/Source/Common/Core.h
+++ b/Source/Common/Core.h
@@ -186,6 +186,7 @@ private:
     std::string get_last_modification_file(const std::string& file);
     bool        file_is_existing(const std::string& filename);
     void compress_report(std::string& report, MediaConchLib::compression& compress);
+    void compress_report_copy(std::string& report, const char* src, size_t src_len, MediaConchLib::compression& compress);
     int  uncompress_report(std::string& report, MediaConchLib::compression compress);
     void get_report_saved(const std::vector<std::string>& file, MediaConchLib::report reportKind, MediaConchLib::format f, std::string& report);
     void get_reports_output(const std::vector<std::string>& files,


### PR DESCRIPTION
Use a dedicated feature of MediaInfoLib, fallback on the previous method if MediaInfoLib version does not support the feature.