### PR TITLE
QMake: replaces CXXFLAGS by DEFINES in MediaConch.pro

### DIFF
--- a/Project/Qt/MediaConch.pro
+++ b/Project/Qt/MediaConch.pro
@@ -172,7 +172,7 @@ equals(WEB_MACHINE, webengine) {
                ../../Source/GUI/Qt/WebEngineView.cpp
     HEADERS += ../../Source/GUI/Qt/WebEnginePage.h \
                ../../Source/GUI/Qt/WebEngineView.h
-    QMAKE_CXXFLAGS   += -DWEB_MACHINE_ENGINE
+    DEFINES += WEB_MACHINE_ENGINE
 } else {
     greaterThan(QT_MAJOR_VERSION, 4) {
         !qtHaveModule(webkit) {
@@ -191,7 +191,7 @@ equals(WEB_MACHINE, webengine) {
                ../../Source/GUI/Qt/WebKitView.cpp
     HEADERS += ../../Source/GUI/Qt/WebKitPage.h \
                ../../Source/GUI/Qt/WebKitView.h
-    QMAKE_CXXFLAGS   += -DWEB_MACHINE_KIT
+    DEFINES += WEB_MACHINE_KIT
 }
 
 INCLUDEPATH      += ../../Source
@@ -250,7 +250,7 @@ unix:exists(../../../libxslt/libxslt/.libs/libxslt.a) {
 contains(NO_SQLITE, yes|1) {
     message("libsqlite3  : no")
 } else {
-    QMAKE_CXXFLAGS   += -DHAVE_SQLITE
+    DEFINES              += HAVE_SQLITE
     unix:exists(../../../sqlite/.libs/libsqlite3.a) {
         INCLUDEPATH      += ../../../sqlite
         LIBS             += ../../../sqlite/.libs/libsqlite3.a
@@ -264,7 +264,7 @@ contains(NO_SQLITE, yes|1) {
 contains(NO_JANSSON, yes|1) {
     message("libjansson  : no")
 } else {
-    QMAKE_CXXFLAGS   += -DHAVE_JANSSON
+    DEFINES              += HAVE_JANSSON
     unix:exists(../../../jansson/src/.libs/libjansson.a) {
         INCLUDEPATH      += ../../../jansson/src
         LIBS             += ../../../jansson/src/.libs/libjansson.a
@@ -278,7 +278,7 @@ contains(NO_JANSSON, yes|1) {
 contains(NO_LIBEVENT, yes|1) {
     message("libevent    : no")
 } else {
-    QMAKE_CXXFLAGS   += -DHAVE_LIBEVENT
+    DEFINES              += HAVE_LIBEVENT
     unix:exists(../../../libevent/.libs/libevent.a) {
         INCLUDEPATH      += ../../../libevent/include
         LIBS             += ../../../libevent/.libs/libevent.a
@@ -293,7 +293,7 @@ contains(NO_LIBCURL, yes|1) {
     message("use libcurl : no")
 } else {
     message("use libcurl : yes (from libmediainfo)")
-    QMAKE_CXXFLAGS   += -DMEDIAINFO_LIBCURL_YES
+    DEFINES += MEDIAINFO_LIBCURL_YES
 }
 
 macx:QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.5


### PR DESCRIPTION
Signed-off-by: Maxime Gervais <gervais.maxime@gmail.com>

QMAKE_CXXFLAGS  aren't passed to C preprocessor by moc, making impossible to use webkit with Qt5.6+