### PR TITLE
Fix MacOS build

### DIFF
--- a/Project/GNU/CLI/AddThisToRoot_CLI_compile.sh
+++ b/Project/GNU/CLI/AddThisToRoot_CLI_compile.sh
@@ -90,9 +90,9 @@ if test -e MediaInfoLib/Project/GNU/Library/configure; then
     test -e Makefile && rm Makefile
     chmod +x configure
     if [ "$OS" = "mac" ]; then
-        ./configure --enable-staticlibs --enable-static --disable-shared $MacOptions --with-libcurl=runtime $*
+        ./configure --enable-static --disable-shared $MacOptions --with-libcurl=runtime $*
     else
-        ./configure --enable-staticlibs --enable-static --disable-shared --with-libcurl $*
+        ./configure --enable-static --disable-shared --with-libcurl $*
     fi
     if test ! -e Makefile; then
         echo Problem while configuring MediaInfoLib

--- a/Project/GNU/GUI/AddThisToRoot_GUI_compile.sh
+++ b/Project/GNU/GUI/AddThisToRoot_GUI_compile.sh
@@ -95,9 +95,9 @@ if test -e MediaInfoLib/Project/GNU/Library/configure; then
     test -e Makefile && rm Makefile
     chmod +x configure
     if [ "$OS" = "mac" ]; then
-        ./configure --enable-staticlibs --enable-static --disable-shared $MacOptions --with-libcurl=runtime $*
+        ./configure --enable-static --disable-shared $MacOptions --with-libcurl=runtime $*
     else
-        ./configure --enable-staticlibs --enable-static --disable-shared --with-libcurl $*
+        ./configure --enable-static --disable-shared --with-libcurl $*
     fi
     if test ! -e Makefile; then
         echo Problem while configuring MediaInfoLib

--- a/Project/GNU/Server/AddThisToRoot_Server_compile.sh
+++ b/Project/GNU/Server/AddThisToRoot_Server_compile.sh
@@ -54,9 +54,9 @@ if test -e ZenLib/Project/GNU/Library/configure; then
     test -e Makefile && rm Makefile
     chmod +x configure
     if [ "$OS" = "mac" ]; then
-        ./configure --enable-staticlibs --enable-static --disable-shared $MacOptions $ZenLib_Options $*
+        ./configure --enable-static --disable-shared $MacOptions $ZenLib_Options $*
     else
-        ./configure --enable-staticlibs --enable-static --disable-shared $ZenLib_Options $*
+        ./configure --enable-static --disable-shared $ZenLib_Options $*
     fi
     if test ! -e Makefile; then
         echo Problem while configuring ZenLib

--- a/Source/Common/Plugin.cpp
+++ b/Source/Common/Plugin.cpp
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <dirent.h>
-extern char **environ;
 #include <sys/wait.h>
 #endif
 
@@ -234,7 +233,7 @@ namespace MediaConch {
                 args[i] = const_cast<char*>(params[i].c_str());
             args[i] = NULL;
 
-            execvpe(bin, args, environ);
+            execvp(bin, args);
             exit(1);
         }
         else


### PR DESCRIPTION
- MacOS libc don't provide execvpe
- execvp seem sufficient for passing unmodified environment
- Fix build scripts

Signed-off-by: Maxime Gervais <gervais.maxime@gmail.com>