### PR TITLE
Version in Policy Editor

### DIFF
--- a/Source/Common/generated/GeneratedCSVVideos.h
+++ b/Source/Common/generated/GeneratedCSVVideos.h
@@ -2394,11 +2394,11 @@ int get_generated_values_from_csv(std::map<std::string, std::map<std::string, st
         }
         {
             std::vector<std::string> tmp_vec;
-            tmp_vec.push_back("Version 0");
-            tmp_vec.push_back("Version 1");
-            tmp_vec.push_back("Version 2");
-            tmp_vec.push_back("Version 3");
-            tmp_vec.push_back("Version 3.4");
+            tmp_vec.push_back("0");
+            tmp_vec.push_back("1");
+            tmp_vec.push_back("2");
+            tmp_vec.push_back("3");
+            tmp_vec.push_back("3.4");
             tmp["Format_Version"] = tmp_vec;
         }
         {


### PR DESCRIPTION
Policy Editor uses Version fields from MediaInfo report, but for new XML we decided to remove "Version " from the Version field, so manually removing "Version " from the list.

@tribouille at long term there is a need to handle this specific case in the list creation tool.