### PR TITLE
GUI: truncate when saving a policy to a file

### DIFF
--- a/Source/GUI/Qt/WebCommonPage.cpp
+++ b/Source/GUI/Qt/WebCommonPage.cpp
@@ -72,7 +72,7 @@ namespace MediaConch {
         mainwindow->set_last_save_report_path(info.absolutePath().toUtf8().data());
 
         QFile file(dl_file);
-        if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
+        if (!file.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate))
             return;
 
         QTextStream out(&file);

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -877,7 +877,7 @@ int MainWindow::policy_export_data(const QString& policy, const QString& p_name,
     set_last_save_policy_path(info.absolutePath().toUtf8().data());
 
     QFile file(filename);
-    if (file.open(QIODevice::ReadWrite))
+    if (file.open(QIODevice::ReadWrite | QIODevice::Truncate))
     {
         QTextStream stream(&file);
         stream << policy;


### PR DESCRIPTION
Fix: https://github.com/MediaArea/MediaConch/issues/161

Signed-off-by: Florent Tribouilloy <florent@mediaarea.net>