### PR TITLE
allow mmt rule to reference elemental names

### DIFF
--- a/Tools/Policies/policyset2policytransform2policyresult.xsl
+++ b/Tools/Policies/policyset2policytransform2policyresult.xsl
@@ -387,17 +387,35 @@
     <xsl:choose>
       <xsl:when test="$remaining">
         <xsl:choose>
-          <xsl:when test="@scope='mmt'">
-            <xsl:text>/mmt:b[@n='</xsl:text>
-          </xsl:when>
-          <xsl:when test="@scope='mt'">
-            <xsl:text>/mt:block[@name='</xsl:text>
+          <xsl:when test="substring($first,1,2)='m:'">
+          <xsl:choose>
+            <xsl:when test="@scope='mmt'">
+              <xsl:text>/mmt:b[mmt:b[@n='Header']/mmt:d[@n='Name']='</xsl:text>
+            </xsl:when>
+            <xsl:when test="@scope='mt'">
+              <xsl:text>/mt:block[mt:block[@name='Header']/mt:data[@name='Name']='</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:text>/mi:</xsl:text>
+            </xsl:otherwise>
+          </xsl:choose>
+          <xsl:value-of select="substring($first,3)"/>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:text>/mi:</xsl:text>
+            <xsl:choose>
+              <xsl:when test="@scope='mmt'">
+                <xsl:text>/mmt:b[@n='</xsl:text>
+              </xsl:when>
+              <xsl:when test="@scope='mt'">
+                <xsl:text>/mt:block[@name='</xsl:text>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:text>/mi:</xsl:text>
+              </xsl:otherwise>
+            </xsl:choose>
+            <xsl:value-of select="$first"/>
           </xsl:otherwise>
         </xsl:choose>
-        <xsl:value-of select="$first"/>
         <xsl:choose>
           <xsl:when test="@scope='mmt' or @scope='mt'">
             <xsl:text>']</xsl:text>
@@ -424,19 +442,42 @@
           </xsl:when>
           <xsl:otherwise>
             <xsl:choose>
-              <xsl:when test="@scope='mmt'">
-                <xsl:text>/mmt:d[@n='</xsl:text>
+              <xsl:when test="substring($first,1,2)='m:'">
+                <xsl:choose>
+                  <xsl:when test="@scope='mmt'">
+                    <xsl:text>/mmt:b[mmt:b[@n='Header']/mmt:d[@n='Name']='</xsl:text>
+                  </xsl:when>
+                  <xsl:when test="@scope='mt'">
+                    <xsl:text>/mt:block[mt:block[@name='Header']/mt:data[@name='Name']='</xsl:text>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:text>/mi:</xsl:text>
+                  </xsl:otherwise>
+                </xsl:choose>
+                <xsl:value-of select="substring($first,3)"/>
+                <xsl:choose>
+                  <xsl:when test="@scope='mmt' or @scope='mt'">
+                    <xsl:text>']</xsl:text>
+                  </xsl:when>
+                </xsl:choose>
               </xsl:when>
-              <xsl:when test="@scope='mmt'">
-                <xsl:text>/mt:data[@name='</xsl:text>
-              </xsl:when>
-              <xsl:otherwise>/mi:</xsl:otherwise>
-            </xsl:choose>
-            <xsl:value-of select="$first"/>
-            <xsl:choose>
-              <xsl:when test="@scope='mmt' or @scope='mt'">
-                <xsl:text>']</xsl:text>
-              </xsl:when>
+              <xsl:otherwise>
+                <xsl:choose>
+                  <xsl:when test="@scope='mmt'">
+                    <xsl:text>/mmt:d[@n='</xsl:text>
+                  </xsl:when>
+                  <xsl:when test="@scope='mmt'">
+                    <xsl:text>/mt:data[@name='</xsl:text>
+                  </xsl:when>
+                  <xsl:otherwise>/mi:</xsl:otherwise>
+                </xsl:choose>
+                <xsl:value-of select="$first"/>
+                <xsl:choose>
+                  <xsl:when test="@scope='mmt' or @scope='mt'">
+                    <xsl:text>']</xsl:text>
+                  </xsl:when>
+                </xsl:choose>
+              </xsl:otherwise>
             </xsl:choose>
           </xsl:otherwise>
         </xsl:choose>


### PR DESCRIPTION
for instance allows:

`m:moov/m:trak/m:mdia/m:minf/m:stbl/m:stsd/Video/m:pasp`

as an alternate to

`File header/Track/Media/Media Information/Sample Table/Sample
Description/Video/Pixel Nope/Header/Name`

to optimize path references in mov, avi, etc