### PR TITLE
Policy: do not set the isPublic policy when exporting policy

### DIFF
--- a/Source/Common/Policies.cpp
+++ b/Source/Common/Policies.cpp
@@ -237,7 +237,7 @@ int Policies::save_policy(int user, int id, std::string& err)
     if (policy->type == POLICY_XSLT && ((XsltPolicy*)policy)->parent_id != (size_t)-1)
         return save_policy(user, ((XsltPolicy*)policy)->parent_id, err);
 
-    return export_policy(user, NULL, id, err);
+    return export_policy(user, NULL, id, err, true);
 }
 
 int Policies::duplicate_policy(int user, int id, int dst_policy_id, int *dst_user, bool must_be_public, std::string& err, bool copy_name)
@@ -313,7 +313,7 @@ int Policies::duplicate_policy(int user, int id, int dst_policy_id, int *dst_use
 
     find_save_name(destination_user, NULL, p->filename, p->name.c_str());
     if (p->type == POLICY_UNKNOWN)
-        export_policy(destination_user, p->filename.c_str(), old->id, err);
+        export_policy(destination_user, p->filename.c_str(), old->id, err, false);
 
     return (int)p->id;
 }
@@ -334,7 +334,7 @@ int Policies::move_policy(int user, int id, int dst_policy_id, std::string& err)
     return new_id;
 }
 
-int Policies::export_policy(int user, const char* filename, int id, std::string& err)
+int Policies::export_policy(int user, const char* filename, int id, std::string& err, bool is_save)
 {
     Policy *p = get_policy(user, id, err);
     if (!p)
@@ -347,6 +347,8 @@ int Policies::export_policy(int user, const char* filename, int id, std::string&
 
         filename = p->filename.c_str();
     }
+
+    p->set_keep_public(is_save);
 
     return p->export_schema(filename, err);
 }
@@ -362,6 +364,8 @@ int Policies::dump_policy_to_memory(int user, int id, bool must_be_public, std::
         err = "This policy is not a public policy";
         return -1;
     }
+
+    p->set_keep_public(false);
 
     if (p->dump_schema(memory) < 0)
     {
@@ -863,6 +867,7 @@ xmlDocPtr Policies::create_doc(int user, int id)
     if (!p)
         return NULL;
 
+    p->set_keep_public(true);
     return p->create_doc();
 }
 

--- a/Source/Common/Policies.h
+++ b/Source/Common/Policies.h
@@ -68,7 +68,7 @@ public:
     int         create_xslt_policy_from_file(int user, long file, std::string& err);
 
     int         save_policy(int user, int id, std::string& err);
-    int         export_policy(int user, const char* filename, int id, std::string& err);
+    int         export_policy(int user, const char* filename, int id, std::string& err, bool is_save=false);
     int         dump_policy_to_memory(int user, int pos, bool must_be_public, std::string& memory, std::string& err);
 
     int         policy_change_info(int user, int id, const std::string& name, const std::string& description,

--- a/Source/Common/Policy.cpp
+++ b/Source/Common/Policy.cpp
@@ -26,7 +26,8 @@ namespace MediaConch {
 //***************************************************************************
 
 //---------------------------------------------------------------------------
-Policy::Policy(Policies *p, Policies::PolicyType t, bool n_https) : type(t), is_system(false), no_https(n_https), is_public(false), policies(p)
+    Policy::Policy(Policies *p, Policies::PolicyType t, bool n_https) : type(t), is_system(false), no_https(n_https),
+                                                                        is_public(false), keep_public(true), policies(p)
 {
     this->id = p->get_an_id();
 }
@@ -42,6 +43,7 @@ Policy::Policy(const Policy* p)
     this->license = p->license;
     this->is_system = false;
     this->is_public = p->is_public;
+    this->keep_public = p->keep_public;
     this->no_https = p->no_https;
     this->policies = p->policies;
     this->id = p->policies->get_an_id();
@@ -58,6 +60,7 @@ Policy::Policy(const Policy& p)
     this->license = p.license;
     this->is_system = p.is_system;
     this->is_public = p.is_public;
+    this->keep_public = p.keep_public;
     this->no_https = p.no_https;
     this->policies = p.policies;
     this->id = p.id;

--- a/Source/Common/Policy.h
+++ b/Source/Common/Policy.h
@@ -53,6 +53,7 @@ public:
     int                  dump_schema(std::string& data);
     std::string          get_error() const { return error; }
     virtual xmlDocPtr    create_doc() = 0;
+    void                 set_keep_public(bool b) { keep_public = b;}
 
     std::string          filename;
     std::string          name;
@@ -63,6 +64,7 @@ public:
     bool                 is_system;
     bool                 no_https;
     bool                 is_public;
+    bool                 keep_public;
 
 protected:
     Policies            *policies;

--- a/Source/Common/XsltPolicy.cpp
+++ b/Source/Common/XsltPolicy.cpp
@@ -507,7 +507,7 @@ int XsltPolicy::create_node_policy_child(xmlNodePtr& node, XsltPolicy *current)
     }
 
     //isPublic
-    if (current->is_public)
+    if (current->keep_public && current->is_public)
         xmlNewProp(node, (const xmlChar *)"isPublic", (const xmlChar *)"true");
 
     //license


### PR DESCRIPTION
Signed-off-by: Florent Tribouilloy <florent@mediaarea.net>