### PR TITLE
Completely stop the parsing when remove is requested from the UI.

### DIFF
--- a/Source/Common/Queue.h
+++ b/Source/Common/Queue.h
@@ -75,6 +75,7 @@ namespace MediaConch
     private:
         Scheduler*                         scheduler;
         MediaInfoNameSpace::MediaInfo     *MI;
+        ZenLib::CriticalSection            MI_CS;
     };
 
     //***************************************************************************

--- a/Source/Common/Scheduler.cpp
+++ b/Source/Common/Scheduler.cpp
@@ -170,6 +170,7 @@ namespace MediaConch {
             {
                 if (it->first && it->first->user == user && it->first->file_id == vec[i])
                 {
+                    it->first->stop(); 
                     remove_element(it->first);
                     break;
                 }


### PR DESCRIPTION
Uses a new option in MediaInfoLib, up to date version is requested.