### PR TITLE
Creation of rule from a media skips "/String" fields

### DIFF
--- a/Source/Common/XsltPolicy.cpp
+++ b/Source/Common/XsltPolicy.cpp
@@ -717,6 +717,7 @@ int XsltPolicy::create_rule_from_media_track_child(xmlNodePtr node, const std::s
          || name == "Delay"
          || name == "Count"
          || name == "CodecID_Url"
+         || name.find("/String") != std::string::npos
          || name == "ConformanceErrors"
          || name == "ConformanceWarnings"
          || name == "ConformanceInfos")


### PR DESCRIPTION
Can still be created manually, but creating corresponding policy rules makes a huge list by default.